### PR TITLE
Change references to last-command-char to last-command-event as the

### DIFF
--- a/groovy-electric.el
+++ b/groovy-electric.el
@@ -126,14 +126,14 @@ have Font Lock enabled. ${ } is expanded when in a GString"
 	   (save-excursion
 		 (char-equal ?\" (char-after (car (c-literal-limits)))))))
 
-(defun groovy-electric-is-last-command-char-expandable-punct-p()
+(defun groovy-electric-is-last-command-event-expandable-punct-p()
   (or (memq 'all groovy-electric-expand-delimiters-list)
-      (memq last-command-char groovy-electric-expand-delimiters-list)))
+      (memq last-command-event groovy-electric-expand-delimiters-list)))
 
 (defun groovy-electric-curlies(arg)
   (interactive "P")
   (self-insert-command (prefix-numeric-value arg))
-  (when (and (groovy-electric-is-last-command-char-expandable-punct-p)
+  (when (and (groovy-electric-is-last-command-event-expandable-punct-p)
 			 (groovy-electric-code-at-point-p))
 	(insert " ")
 	(save-excursion
@@ -144,16 +144,16 @@ have Font Lock enabled. ${ } is expanded when in a GString"
 (defun groovy-electric-matching-char(arg)
   (interactive "P")
   (self-insert-command (prefix-numeric-value arg))
-  (and (groovy-electric-is-last-command-char-expandable-punct-p)
+  (and (groovy-electric-is-last-command-event-expandable-punct-p)
        (groovy-electric-code-at-point-p)
        (save-excursion
-		 (insert (cdr (assoc last-command-char
+		 (insert (cdr (assoc last-command-event
 							 groovy-electric-matching-delimeter-alist))))))
 
 (defun groovy-electric-pound(arg)
   (interactive "P")
   (self-insert-command (prefix-numeric-value arg))
-  (when (and (groovy-electric-is-last-command-char-expandable-punct-p)
+  (when (and (groovy-electric-is-last-command-event-expandable-punct-p)
 			 (groovy-electric-gstring-at-point-p)
 			 (not (save-excursion ; make sure it is not escaped
 					(backward-char 1)


### PR DESCRIPTION
former is obsolete in favor of the latter.

last-command-char has been considered obsolete since Emacs 19.34 and has been removed from Emacs 24.3

Use last-command-event instead. Since this is a small standalone file, probably best just to replace the references entirely. Alternatively last-command-char could be used as an alias for last-command-event at the top.