### PR TITLE
Add an entry to interpreter-mode-alist

### DIFF
--- a/groovy-mode.el
+++ b/groovy-mode.el
@@ -419,6 +419,7 @@ need for `java-font-lock-extra-types'.")
 
 ;;----------------------------------------------------------------------------
 ;;;###autoload (add-to-list 'auto-mode-alist '("\\.g\\(?:ant\\|roovy\\|radle\\)\\'" . groovy-mode))
+;;;###autoload (add-to-list 'interpreter-mode-alist '("groovy" . groovy-mode))
 
 ;; Custom variables
 ;;;###autoload


### PR DESCRIPTION
Allow #!groovy and the like to set the mode for a file

I'm not familiar with the magic of the `###autoload` comment, so I might not have it right.
