### PR TITLE
Smarter string highlighting

### DIFF
--- a/groovy-mode.el
+++ b/groovy-mode.el
@@ -311,8 +311,8 @@ The function name is the second group in the regexp.")
                    (backward-char 3)
                    (syntax-ppss)
                  (forward-char 3))))
-    (unless (nth 4 (syntax-ppss)) ;; not inside comment
-      (if (nth 8 (syntax-ppss))
+    (unless (nth 4 ppss) ;; not inside comment
+      (if (nth 8 ppss)
           ;; We're in a string, so this must be the closing triple-quote.
           ;; Put | on the last " character.
           (put-text-property (1- string-end-pos) string-end-pos

--- a/groovy-mode.el
+++ b/groovy-mode.el
@@ -423,7 +423,8 @@ Key bindings:
   (set (make-local-variable 'syntax-propertize-function)
        groovy-syntax-propertize-function)
   (setq imenu-generic-expression groovy-imenu-regexp)
-  (set (make-local-variable 'indent-line-function) #'groovy-indent-line))
+  (set (make-local-variable 'indent-line-function) #'groovy-indent-line)
+  (set (make-local-variable 'comment-start) "//"))
 
 (provide 'groovy-mode)
 

--- a/groovy-mode.el
+++ b/groovy-mode.el
@@ -255,11 +255,16 @@ The function name is the second group in the regexp.")
             (while (and
                     (not res)
                     (re-search-forward pattern limit t))
-              (when (and (groovy--in-string-p)
-                         (not (eq (char-before (match-beginning 0))
-                                  ?\\)))
-                (setq res (point))
-                (setq match-data (match-data)))))
+
+              (let* ((string-delimiter (nth 3 (syntax-ppss)))
+                     (escaped-p (eq (char-before (match-beginning 0))
+                                    ?\\)))
+                (when (and (groovy--in-string-p)
+                           ;; Interpolation does not apply in single-quoted strings.
+                           (not (eq string-delimiter ?'))
+                           (not escaped-p))
+                  (setq res (point))
+                  (setq match-data (match-data))))))
           ;; Set match data and return point so we highlight this
           ;; instance.
           (when res

--- a/groovy-mode.el
+++ b/groovy-mode.el
@@ -262,7 +262,8 @@ The function name is the second group in the regexp.")
                 (when (and (groovy--in-string-p)
                            ;; Interpolation does not apply in single-quoted strings.
                            (not (eq string-delimiter ?'))
-                           (not escaped-p))
+                           (not escaped-p)
+                           (not (equal (match-string 0) "$$")))
                   (setq res (point))
                   (setq match-data (match-data))))))
           ;; Set match data and return point so we highlight this


### PR DESCRIPTION
This makes `groovy-mode` highlight strings more accurately.

* Slashy strings like `/foo/` are now highlighted as strings
* String interpolation is not highlighted in single quoted strings, because it doesn't apply there.

This doesn't cover dollar slashy strings like `$/foo/$`, but this is a definite improvement.

It also ensures `comment-region` does the right thing.