### PR TITLE
Set up test for Issue #56

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+emacs ?= emacs
+
+all: test
+
+test: clean
+	cask exec emacs -Q -batch -l test/unit-test.el -l test/indentation-test.el -f ert-run-tests-batch-and-exit
+
+clean:
+	rm -f groovy-mode.elc
+
+.PHONY:	all test

--- a/test/indentation-test.el
+++ b/test/indentation-test.el
@@ -1,0 +1,71 @@
+(require 'ert)
+
+(load-file "groovy-mode.el")
+
+(ert-deftest test-function-indentation-using-groovy-specific-function ()
+  (with-temp-buffer
+    (let ((text "def f() {
+def a = 1
+}
+"))
+      (insert text)
+      (goto-char (point-min))
+      (groovy-indent-line)
+      (next-line)
+      (groovy-indent-line)
+      (next-line)
+      (groovy-indent-line)
+      (should (equal (buffer-string) "def f() {
+    def a = 1
+}
+")))))
+
+(ert-deftest test-function-indentation-using-generic-function ()
+  (with-temp-buffer
+    (let ((text "def f() {
+def a = 1
+}
+"))
+      (groovy-mode)
+      (insert text)
+      (goto-char (point-min))
+      (indent-line-function)
+      (next-line)
+      (indent-line-function)
+      (next-line)
+      (indent-line-function)
+      (should (equal (buffer-string) "def f() {
+    def a = 1
+}
+")))))
+
+(ert-deftest test-for-issue-56 ()
+  (with-temp-buffer
+    (let ((text "class foo {
+def bar() {
+def a = 1
+def b = a +
+1
+def c =
+1
+def d = a
+.baz()
+}
+}
+"))
+      (groovy-mode)
+      (insert text)
+      (should (equal (buffer-string) text))
+      (indent-region (point-min) (point-max))
+       (should (equal (buffer-string) "class foo {
+    def bar() {
+        def a = 1
+        def b = a +
+            1
+        def c =
+            1
+        def d = a
+            .baz()
+    }
+}
+")))))

--- a/test/unit-test.el
+++ b/test/unit-test.el
@@ -1,5 +1,6 @@
 (require 'ert)
-(require 'groovy-mode)
+
+(load-file "groovy-mode.el")
 
 (ert-deftest groovy-smoke-test ()
   "Ensure that we can activate the Groovy major mode."


### PR DESCRIPTION
Here are the beginnings of some indentation tests prompted by Issue #56. Sadly the tests fail, not because of indentation issues, but because executing `(groovy-mode)` in the test function does not appear to define `indent-line-function` which the mode function claims to set as a per-buffer variable. In the test function it's value is `nil` not `groovy-indent-line`.

Clearly this pull request cannot really be merged till this problem is sorted. Even then it probably needs the groovy-indent-line function amending to fix the problem of Issue #56. 