### PR TITLE
Fix failing indent test

### DIFF
--- a/groovy-mode.el
+++ b/groovy-mode.el
@@ -418,7 +418,7 @@ dollar-slashy-quoted strings."
   "Does STR end with an infix operator?"
   (string-match-p
    (rx
-    symbol-start
+    (or symbol-end space)
     ;; http://docs.groovy-lang.org/next/html/documentation/core-operators.html
     (or "+" "-" "*" "/" "%" "**"
         "=" "+=" "-=" "*=" "/=" "%=" "**="

--- a/test/unit-test.el
+++ b/test/unit-test.el
@@ -38,6 +38,9 @@ bar()
   "We should increase indent after infix operators."
   (should-preserve-indent
    "def a = b +
+    1")
+  (should-preserve-indent
+   "def a = b+
     1"))
 
 (ert-deftest groovy-indent-infix-closure ()


### PR DESCRIPTION
Since + is treated as punctuation, we can't use symbol-start.

Also add a test for not having whitespace before the operator.