### PR TITLE
prevent indenting closures like other things

### DIFF
--- a/groovy-mode.el
+++ b/groovy-mode.el
@@ -559,7 +559,8 @@ Then this function returns (\"def\" \"if\" \"switch\")."
      ;; correctly.
      ((and (not (s-blank-str? text-after-paren))
            (not has-closing-paren)
-           (not (equal text-after-paren "->")))
+           ;; ensure we don't indent closures
+           (not (string-match (rx "->" eol) text-after-paren)))
       (let (open-paren-column)
         (save-excursion
           (goto-char current-paren-pos)

--- a/test/unit-test.el
+++ b/test/unit-test.el
@@ -59,6 +59,12 @@ bar()
     def f = { ->
         \"foo\"
     }
+}")
+  (should-preserve-indent
+   "def foo() {
+    def f = { def bar ->
+        \"foo\"
+    }
 }"))
 
 (ert-deftest groovy-indent-method-call ()


### PR DESCRIPTION
fixes https://github.com/Groovy-Emacs-Modes/groovy-emacs-modes/issues/80