### PR TITLE
Correctly indent repeated parens

### DIFF
--- a/groovy-mode.el
+++ b/groovy-mode.el
@@ -655,6 +655,22 @@ Then this function returns (\"def\" \"if\" \"switch\")."
        (seq "default" symbol-end))
       ":"))
 
+(defun groovy--effective-paren-depth (pos)
+  "Return the paren depth of position POS, but ignore repeated parens on the same line."
+  (let ((paren-depth 0)
+        (syntax (syntax-ppss pos)))
+    (save-excursion
+      (while (> (nth 0 syntax) 0)
+        (setq paren-depth (1+ paren-depth))
+        ;; Go to the most recent open paren.
+        (goto-char (nth 1 syntax))
+        ;; Move the previous line, ignoring any other parens on the
+        ;; same line.
+        (goto-char (1- (line-beginning-position)))
+
+        (setq syntax (syntax-ppss (point)))))
+    paren-depth))
+
 (defun groovy-indent-line ()
   "Indent the current line according to the number of parentheses."
   (interactive)
@@ -662,7 +678,7 @@ Then this function returns (\"def\" \"if\" \"switch\")."
          (syntax-bol (syntax-ppss (line-beginning-position)))
          (multiline-string-p (nth 3 syntax-bol))
          (multiline-comment-p (nth 4 syntax-bol))
-         (current-paren-depth (nth 0 syntax-bol))
+         (current-paren-depth (groovy--effective-paren-depth (line-beginning-position)))
          (current-paren-pos (nth 1 syntax-bol))
          (text-after-paren
           (when current-paren-pos

--- a/test/unit-test.el
+++ b/test/unit-test.el
@@ -67,6 +67,13 @@ bar()
     }
 }"))
 
+(ert-deftest groovy-indent-repeated-parens ()
+  "We should only indent by one level inside closures."
+  (should-preserve-indent
+   "def x = [[
+    1
+]]"))
+
 (ert-deftest groovy-indent-method-call ()
   "We should increase indent for method calls"
   (should-preserve-indent


### PR DESCRIPTION
This fixes cases like:

```groovy
foo([
    1
])
```

where we only want to indent the 1 by a single indentation level, even
though we are inside two parens.

We now only increase indent level for at most one paren per line of
code.

Fixes #78.