### PR TITLE
Comment indent fixes

### DIFF
--- a/groovy-mode.el
+++ b/groovy-mode.el
@@ -9,7 +9,7 @@
 ;; Created: 2006-08-01
 ;; Keywords: languages
 ;; Version: 2.1
-;; Package-Requires: ((s "1.12.0") (emacs "24.3"))
+;; Package-Requires: ((s "1.12.0") (emacs "24.3") (dash "2.13.0"))
 
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -41,6 +41,7 @@
 ;;; Code:
 
 (require 's)
+(require 'dash)
 
 (defvar groovy-mode-syntax-table
   (let ((table (make-syntax-table)))
@@ -655,6 +656,12 @@ Then this function returns (\"def\" \"if\" \"switch\")."
        (seq "default" symbol-end))
       ":"))
 
+(defun groovy--remove-comments (src)
+  "Remove all comments from a string of groovy source code."
+  (->> src
+       (replace-regexp-in-string (rx "/*" (*? anything) "*/") "")
+       (replace-regexp-in-string (rx "//" (* not-newline)) "")))
+
 (defun groovy--effective-paren-depth (pos)
   "Return the paren depth of position POS, but ignore repeated parens on the same line."
   (let ((paren-depth 0)
@@ -689,9 +696,10 @@ Then this function returns (\"def\" \"if\" \"switch\")."
             (save-excursion
               (goto-char current-paren-pos)
               (s-trim
-               (buffer-substring
-                (1+ current-paren-pos)
-                (line-end-position))))))
+               (groovy--remove-comments
+                (buffer-substring
+                 (1+ current-paren-pos)
+                 (line-end-position)))))))
          (current-line (s-trim (groovy--current-line)))
          has-closing-paren)
     ;; If this line starts with a closing paren, unindent by one level.

--- a/test/unit-test.el
+++ b/test/unit-test.el
@@ -17,7 +17,8 @@
      (setq indent-tabs-mode nil)
      (shut-up
        (indent-region (point-min) (point-max)))
-     (should (equal (buffer-string) ,result))))
+     (should (equal (buffer-substring-no-properties (point-min) (point-max))
+                    ,result))))
 
 (defmacro should-preserve-indent (source)
   "Assert that SOURCE does not change when indented."

--- a/test/unit-test.el
+++ b/test/unit-test.el
@@ -34,6 +34,11 @@ bar()
 }"
    "def foo() {
     bar()
+}")
+  ;; Ensure we're not confused by comments.
+  (should-preserve-indent
+   "def foo() { // blah
+    def bar = 123
 }"))
 
 (ert-deftest groovy-indent-infix-operator ()
@@ -365,3 +370,17 @@ then run BODY."
   (with-highlighted-groovy "private List<String> fooBar() {"
     (search-forward "foo")
     (should (memq 'font-lock-function-name-face (faces-at-point)))))
+
+(ert-deftest groovy--remove-comments ()
+  (should
+   (equal
+    (groovy--remove-comments "foo\nbar")
+    "foo\nbar"))
+  (should
+   (equal
+    (groovy--remove-comments "foo // bar")
+    "foo "))
+  (should
+   (equal
+    (groovy--remove-comments "foo /* bar */ baz")
+    "foo  baz")))


### PR DESCRIPTION
Ensure that we indent code correctly even when there are comments inside opening parens.