### PR TITLE
Correctly highlight """foo/"""

### DIFF
--- a/Cask
+++ b/Cask
@@ -1,4 +1,3 @@
-(source gnu)
 (source melpa)
 
 (development

--- a/test/unit-test.el
+++ b/test/unit-test.el
@@ -174,7 +174,11 @@ then run BODY."
   ;; Ensure we handle triple-single-quotes inside a triple-double-quotes.
   (with-highlighted-groovy "foo = \"\"\"aaa ''' bbb ''' ccc\"\"\""
     (search-forward "bbb")
-    (should (eq (face-at-point) 'font-lock-string-face))))
+    (should (eq (face-at-point) 'font-lock-string-face)))
+  ;; Ensure that we handle / at the end of a triple-quoted string.
+  (with-highlighted-groovy "blah \"\"\"baz/\"\"\"\n// foo"
+    (search-forward "f")
+    (should (eq (face-at-point) 'font-lock-comment-face))))
 
 (ert-deftest groovy-highlight-triple-single-quote ()
   ;; Ensure we handle single ' correctly inside a triple-single-quoted string.


### PR DESCRIPTION
Functions applying string properties need to leave point at the place
where they want parsing to continue from.

Previously, since we matched two characters with
groovy-slashy-open-regex, we would put point after the first closing
doublequote, giving `"""foo/"|""`. This would stop us seeing the whole
`"""` and we wouldn't consider the triple-quoted string literal to be
closed.

In this circumstance, we now set the point immediately after the `/`.