### PR TITLE
Ensure that we highlight dollar-slashy-strings correctly

### DIFF
--- a/groovy-mode.el
+++ b/groovy-mode.el
@@ -563,12 +563,26 @@ dollar-slashy-quoted strings."
          ;; highlighting is correct even when the mode is started
          ;; initially.
          (in-string (nth 3 (parse-partial-sexp (point-min) delimiter-end-pos))))
-    (unless (or (groovy--comment-p delimiter-end-pos) (not in-string)
-                ;; Ignore $/$ as it's escaped and not a /$ close delimiter.
-                (looking-back (rx "$/$") 3))
+    (cond
+     ((groovy--comment-p delimiter-end-pos)
+      ;; Do nothing inside comments.
+      nil)
+     ((not in-string)
+      ;; If we're not in a string, then /$ is the start of a normal
+      ;; slashy-string, e.g. /$ foo/.
+      ;;
+      ;; Note that both `groovy-stringify-dollar-slashy-close' and
+      ;; `groovy-stringify-slashy-string' expect to be two characters
+      ;; after the /, so we don't need to move point before calling.
+      (groovy-stringify-slashy-string))
+     ((looking-back (rx "$/$") 3)
+      ;; Ignore $/$ as it's escaped and not a /$ close delimiter.
+      nil)
+     (t
+      ;; Otherwise, this is indeed closing a dollar-slashy-string.
       ;; Mark the $ in /$ as a generic string delimiter.
       (put-text-property (- delimiter-end-pos 1) delimiter-end-pos
-                         'syntax-table (string-to-syntax "|")))))
+                         'syntax-table (string-to-syntax "|"))))))
 
 
 (defconst groovy-syntax-propertize-function
@@ -578,18 +592,32 @@ dollar-slashy-quoted strings."
    ;; comment.
    (groovy-shebang-regex
     (0 "< b"))
+
+   ;; WARNING: These are a pain to refactor. Emacs tries each one of
+   ;; these regexps in order. It resumes parsing from wherever point
+   ;; is left at the end of the function call.
+   ;;
+   ;; As a result, it's important that these functions move point
+   ;; backwards if they may have moved over another delimiter (e.g. /$
+   ;; and /). However, they must all move point by a non-zero amount,
+   ;; or you get an infinite loop during fontification.
+   ;;
+   ;; The unit tests are pretty thorough, so they should catch any
+   ;; issues.
    (groovy-triple-double-quoted-string-regex
     (0 (ignore (groovy-stringify-triple-quote))))
    (groovy-triple-single-quoted-string-regex
     (0 (ignore (groovy-stringify-triple-quote))))
-   ;; http://groovy-lang.org/syntax.html#_slashy_string
-   (groovy-slashy-open-regex
-    (0 (ignore (groovy-stringify-slashy-string))))
+
    ;; http://groovy-lang.org/syntax.html#_dollar_slashy_string
    (groovy-dollar-slashy-open-regex
     (0 (ignore (groovy-stringify-dollar-slashy-open))))
    (groovy-dollar-slashy-close-regex
-    (0 (ignore (groovy-stringify-dollar-slashy-close))))))
+    (0 (ignore (groovy-stringify-dollar-slashy-close))))
+
+   ;; http://groovy-lang.org/syntax.html#_slashy_string
+   (groovy-slashy-open-regex
+    (0 (ignore (groovy-stringify-slashy-string))))))
 
 (defgroup groovy nil
   "A Groovy major mode."

--- a/test/unit-test.el
+++ b/test/unit-test.el
@@ -294,10 +294,6 @@ then run BODY."
 final int foo = -1;"
     (search-forward "foo")
     (should (not (memq 'font-lock-string-face (faces-at-point)))))
-  ;; Don't get confused by $ inside a slashy string.
-  (with-highlighted-groovy "x = /$ foo $/"
-    (search-forward "foo")
-    (should (memq 'font-lock-string-face (faces-at-point))))
   ;; Don't get confused by comments.
   (with-highlighted-groovy
       "def bar /* foo */"
@@ -309,6 +305,24 @@ final int foo = -1;"
       "x = /foo\\// + bar"
     (search-forward "bar")
     (forward-char -1)
+    (should (not (memq 'font-lock-string-face (faces-at-point))))))
+
+(ert-deftest groovy-highlight-slashy-string--inner-dollar ()
+  "Don't get confused by slashy-strings that contain $."
+  (with-highlighted-groovy "x = /$ foo $/"
+    (search-forward "foo")
+    (should (memq 'font-lock-string-face (faces-at-point)))))
+
+(ert-deftest groovy-highlight-dollar-slashy-string ()
+  "Highlight $/foo/$ as a string."
+  ;; Ensure that the contents are highlighted as a string.
+  (with-highlighted-groovy "x = $/foo/$"
+    (search-forward "foo")
+    (should (memq 'font-lock-string-face (faces-at-point))))
+  ;; Ensure that later code is not highlighted as a string
+  (with-highlighted-groovy "x = $/foo/$
+bar"
+    (search-forward "b")
     (should (not (memq 'font-lock-string-face (faces-at-point))))))
 
 (ert-deftest groovy-highlight-variable-assignment ()


### PR DESCRIPTION
This had no tests before, and it had been broken.

Fix the logic by always calling the dollar-slashy-string functions
first, but delegate to slashy-string-function where appropriate.

Add a test, and also split out a test from
groovy-highlight-slashy-string for the case when we mix slashy-strings
with $. This is easy to break, so having a separate test makes it
easier to spot what's wrong.

Aggressively comment this logic, because it's challenging to work
with.