### PR TITLE
Handle /$ inside triple-quoted strings

### DIFF
--- a/groovy-mode.el
+++ b/groovy-mode.el
@@ -564,7 +564,9 @@ dollar-slashy-quoted strings."
          ;; set yet. Using `parse-partial-sexp' ensures that the
          ;; highlighting is correct even when the mode is started
          ;; initially.
-         (in-string (nth 3 (parse-partial-sexp (point-min) delimiter-end-pos))))
+         (ppss (parse-partial-sexp (point-min) delimiter-end-pos))
+         (in-string (nth 3 ppss))
+         (string-start-pos (nth 8 ppss)))
     (cond
      ((groovy--comment-p delimiter-end-pos)
       ;; Do nothing inside comments.
@@ -581,10 +583,12 @@ dollar-slashy-quoted strings."
       ;; Ignore $/$ as it's escaped and not a /$ close delimiter.
       nil)
      (t
-      ;; Otherwise, this is indeed closing a dollar-slashy-string.
-      ;; Mark the $ in /$ as a generic string delimiter.
-      (put-text-property (- delimiter-end-pos 1) delimiter-end-pos
-                         'syntax-table (string-to-syntax "|"))))))
+      ;; Otherwise, we're in a string.
+      (when (eq (char-after string-start-pos) ?$)
+        ;; If this string opened with $, this is a string of the form
+        ;; $/foo/$. Mark the final $ as a generic string delimiter.
+        (put-text-property (- delimiter-end-pos 1) delimiter-end-pos
+                           'syntax-table (string-to-syntax "|")))))))
 
 
 (defconst groovy-syntax-propertize-function

--- a/test/unit-test.el
+++ b/test/unit-test.el
@@ -249,6 +249,12 @@ then run BODY."
     (search-forward "f")
     (should (eq (face-at-point) 'font-lock-comment-face))))
 
+(ert-deftest groovy-highlight-triple-double-quote--containing-slashy ()
+  "Don't get confused by /$ in a triple-quoted string."
+  (with-highlighted-groovy "\"\"\"\n/$\n\"\"\"\nfoo = 1"
+    (search-forward "foo")
+    (should (not (eq (face-at-point) 'font-lock-string-face)))))
+
 (ert-deftest groovy-highlight-triple-single-quote ()
   ;; Ensure we handle single ' correctly inside a triple-single-quoted string.
   (with-highlighted-groovy "x = '''foo ' bar '''"


### PR DESCRIPTION
Previously, we didn't check the opening delimiter of the string when
we encountered a closing delimiter for a slashy-string.

Fixes #95.