### PR TITLE
Fix out of range error for line following shebang line

### DIFF
--- a/groovy-mode.el
+++ b/groovy-mode.el
@@ -763,9 +763,11 @@ Then this function returns (\"def\" \"if\" \"switch\")."
         (setq code-text (buffer-substring start-pos (point)))
 
         ;; Unless we went all the way to the end of the line, we
-        ;; encountered a comment delimiter // or /*. Remove this delimiter.
+        ;; encountered a comment delimiter //, /* or #. Remove this delimiter.
         (unless (= (point) end-pos)
-          (setq code-text (substring code-text 0 -2)))))
+          (let ((delims '("//" "/*" "#")))
+            (setq code-text (replace-regexp-in-string
+                             (rx-to-string `(seq (or ,@delims) line-end)) "" code-text))))))
 
     ;; Return the part of the line that isn't a comment (may be nil).
     code-text))

--- a/test/unit-test.el
+++ b/test/unit-test.el
@@ -26,6 +26,13 @@
     `(let ((,src-sym ,source))
        (should-indent-to ,src-sym ,src-sym))))
 
+(ert-deftest groovy-shebang ()
+  "Handle shebang line."
+  ;; http://docs.groovy-lang.org/latest/html/documentation/core-syntax.html#_shebang_line
+  (should-preserve-indent
+   "#!/usr/bin/env groovy
+println 'Hello from the shebang line'"))
+
 (ert-deftest groovy-indent-function ()
   "We should indent according to the number of parens."
   (should-indent-to


### PR DESCRIPTION
A shebang line (e.g. `#!/usr/bin/groovy`) at the beginning of the file causes an "Args out of range" error when indenting the next line, since we assume that the comment delimiter is two characters but in this case it's just a "#".