### PR TITLE
Support braced string interpolation after backslashes

### DIFF
--- a/groovy-mode.el
+++ b/groovy-mode.el
@@ -182,6 +182,15 @@
   (save-excursion
     (nth 3 (syntax-ppss pos))))
 
+(defun groovy--preceded-by-odd-number-of-backslashes ()
+  "Return non-nil if point is preceded by an odd number of backslashes."
+  (let ((point (- (point) 2))
+        (slashes 0))
+    (while (eq (char-before point) ?\\)
+      (cl-incf slashes)
+      (cl-decf point))
+    (cl-oddp slashes)))
+
 (defvar groovy-font-lock-keywords
   ;; Annotations are defined with the @interface, which is a keyword:
   ;; http://groovy-lang.org/objectorientation.html#_annotation
@@ -286,8 +295,7 @@
                   (search-forward "${" limit t))
             (let* ((string-delimiter-pos (nth 8 (syntax-ppss)))
                    (string-delimiter (char-after string-delimiter-pos))
-                   (escaped-p (eq (char-before (- (point) 2))
-                                  ?\\)))
+                   (escaped-p (groovy--preceded-by-odd-number-of-backslashes)))
               (when (and (groovy--in-string-p)
                          ;; Interpolation does not apply in single-quoted strings.
                          (not (eq string-delimiter ?'))

--- a/groovy-mode.el
+++ b/groovy-mode.el
@@ -295,7 +295,8 @@
                   (search-forward "${" limit t))
             (let* ((string-delimiter-pos (nth 8 (syntax-ppss)))
                    (string-delimiter (char-after string-delimiter-pos))
-                   (escaped-p (groovy--preceded-by-odd-number-of-backslashes)))
+                   (escaped-p (and (not (eq string-delimiter ?/))
+                                   (groovy--preceded-by-odd-number-of-backslashes))))
               (when (and (groovy--in-string-p)
                          ;; Interpolation does not apply in single-quoted strings.
                          (not (eq string-delimiter ?'))

--- a/test/groovy-unit-test.el
+++ b/test/groovy-unit-test.el
@@ -533,6 +533,23 @@ then run BODY."
     (search-forward "f")
     (should (equal '(font-lock-string-face) (faces-at-point)))))
 
+(ert-deftest groovy-highlight-interpolation-slashy-string ()
+  "Ensure we highlight interpolation in slashy strings."
+  (with-highlighted-groovy "x = /$foo/"
+    (search-forward "$")
+    (should (memq 'font-lock-variable-name-face (faces-at-point))))
+  (with-highlighted-groovy "x = /$foo$bar/"
+    (search-forward "b")
+    (should (memq 'font-lock-variable-name-face (faces-at-point))))
+  (with-highlighted-groovy "x = /${foo}/"
+    (search-forward "f")
+    (should (memq 'font-lock-variable-name-face (faces-at-point))))
+  ;; Only forward slashes actually get escaped in slashy strings, otherwise
+  ;; backslashes are literal.
+  (with-highlighted-groovy "x = /${foo}\\${bar}/"
+    (search-forward "b")
+    (should (memq 'font-lock-variable-name-face (faces-at-point)))))
+
 (ert-deftest groovy-highlight-comments ()
   "Ensure we do not confuse comments with slashy strings."
   (with-highlighted-groovy "// foo"

--- a/test/groovy-unit-test.el
+++ b/test/groovy-unit-test.el
@@ -500,7 +500,22 @@ then run BODY."
   ;; Interpolation after an escaped dollar, i.e. \$$foo
   (with-highlighted-groovy "x = \"\\$$foo\""
     (search-forward "f")
-    (should (memq 'font-lock-variable-name-face (faces-at-point)))) )
+    (should (memq 'font-lock-variable-name-face (faces-at-point))))
+  (with-highlighted-groovy "x = \"${foo}\""
+    (search-forward "f")
+    (should (equal '(font-lock-variable-name-face) (faces-at-point))))
+  (with-highlighted-groovy "x = \"${foo}\\${bar}"
+    (search-forward "b")
+    (should (equal '(font-lock-string-face) (faces-at-point))))
+  (with-highlighted-groovy "x = \"${foo}\\\\${bar}"
+    (search-forward "b")
+    (should (equal '(font-lock-variable-name-face) (faces-at-point))))
+  (with-highlighted-groovy "x = \"${foo}\\\\\\${bar}"
+    (search-forward "b")
+    (should (equal '(font-lock-string-face) (faces-at-point))))
+  (with-highlighted-groovy "x = \"${foo}\\\\\\\\${bar}"
+    (search-forward "b")
+    (should (equal '(font-lock-variable-name-face) (faces-at-point)))))
 
 (ert-deftest groovy-highlight-interpolation-single-quotes ()
   "Ensure we do not highlight interpolation in single-quoted strings."


### PR DESCRIPTION
This change makes the syntax highlighting of braced string interpolation aware
of escaped backslashes. If it finds an even number of backslashes it won't
consider the $ to be escaped and highlight it as a variable.

I kept noticing that even when backslashes were escaped in Groovy (I have to work with quite a few Windows paths), variables wouldn't be highlighted.