### PR TITLE
Fix indentation after a line ending with a slashy string

### DIFF
--- a/groovy-mode.el
+++ b/groovy-mode.el
@@ -651,6 +651,7 @@ dollar-slashy-quoted strings."
    `(or symbol-end
         space
         (syntax string-quote)
+        (syntax string-delimiter)
         (syntax close-parenthesis)
         (regexp ,groovy-postfix-operator-regex))))
 

--- a/test/groovy-unit-test.el
+++ b/test/groovy-unit-test.el
@@ -274,6 +274,12 @@ def func(int a, int b) {
         'arg1',
         'arg2',
     ]
+}")
+  (should-preserve-indent
+   "
+def func(int a, int b) {
+    call_method arg1: /arg1/,
+        arg2: /arg2/
 }"))
 
 (ert-deftest groovy-indent-call-with-comma ()


### PR DESCRIPTION
Indentation seemed broken when my lines ended with a slashy string.

```
def func(int a, int b) {
    call_method arg1: /arg1/,
    arg2: /arg2/
}
```
This was the original result if I remember correctly.