### PR TITLE
Add comment-start-skip

### DIFF
--- a/groovy-mode.el
+++ b/groovy-mode.el
@@ -994,7 +994,9 @@ Key bindings:
        groovy-syntax-propertize-function)
   (setq imenu-generic-expression groovy-imenu-regexp)
   (set (make-local-variable 'indent-line-function) #'groovy-indent-line)
-  (set (make-local-variable 'comment-start) "//"))
+  (set (make-local-variable 'comment-start) "//")
+  (set (make-local-variable 'comment-start-skip)
+       (rx (or "//" "/*" "/**" "/**@") (zero-or-more space))))
 
 (provide 'groovy-mode)
 


### PR DESCRIPTION
This fixes the use of `comment-search-forward`. Without this change the
`comment-search-forward` throws an error about encountering nil when it's
looking at the `comment-start-skip' value.

I hope it's alright I keep opening these pull requests. I can merge them together if that's easier or preferred.