### PR TITLE
Leave Jenkinsfile alone

### DIFF
--- a/groovy-mode.el
+++ b/groovy-mode.el
@@ -64,8 +64,6 @@
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.g\\(?:ant\\|roovy\\|radle\\)\\'" . groovy-mode))
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("Jenkinsfile" . groovy-mode))
-;;;###autoload
 (add-to-list 'interpreter-mode-alist '("groovy" . groovy-mode))
 
 ;; Regexp Constants


### PR DESCRIPTION
The regex currently will match any file that contains the substring `Jenkinsfile`, which means when I visit `jenkinsfile-mode.el`, the major mode will switch to groovy-mode even when I'm looking at an elisp file.

There's a much better [mode for Jenkins](https://github.com/john2x/jenkinsfile-mode) out there already, leave syntax highlighting to that mode.