### PR TITLE
Enable lexical binding across all Elisp files

### DIFF
--- a/grails-mode.el
+++ b/grails-mode.el
@@ -1,4 +1,4 @@
-;;; grails-mode.el --- minor-mode that adds some Grails project management to a grails project
+;;; grails-mode.el --- minor-mode that adds some Grails project management to a grails project  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2010 Jim Morris
 

--- a/groovy-electric.el
+++ b/groovy-electric.el
@@ -1,4 +1,4 @@
-;;; groovy-electric.el --- Electric mode for Groovy
+;;; groovy-electric.el --- Electric mode for Groovy  -*- lexical-binding: t; -*- 
 
 ;; Copyright (C) 2009 Jim Morris
 

--- a/groovy-mode.el
+++ b/groovy-mode.el
@@ -1,4 +1,4 @@
-;;; groovy-mode.el --- Major mode for Groovy source files
+;;; groovy-mode.el --- Major mode for Groovy source files  -*- lexical-binding: t; -*-
 
 ;;  Copyright © 2006, 2009–2010, 2012–2016  Russel Winder
 

--- a/inf-groovy.el
+++ b/inf-groovy.el
@@ -1,4 +1,4 @@
-;;; inf-groovy.el --- inferior Groovy mode – groovy process in a buffer
+;;; inf-groovy.el --- inferior Groovy mode – groovy process in a buffer  -*- lexical-binding: t; -*-
 
 ;;; Inferior Groovy Mode – groovy process in a buffer.
 ;;;                      adapted from cmuscheme.el and inf-haskell.el


### PR DESCRIPTION
Enable lexical binding in grails-mode.el, groovy-electric.el, groovy-mode.el, and inf-groovy.el by adding the lexical-binding: t cookie to the header line of each file.